### PR TITLE
Enable compatibility with Sway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Description
 
-Switches workspaces in the [i3 window manager](https://i3wm.org/) like xmonad.
-This script will always bring the requested workspace to the current monitor
-("output" in i3's terminology). If the requested workspace is showing on another
-monitor, then the current workspace and requested workspace will swap positions
-with each other.
+Switches workspaces in the [i3 window manager](https://i3wm.org/) and
+[sway](https://swaywm.org/) like xmonad. This script will always bring the
+requested workspace to the current monitor ("output" in i3's terminology). If
+the requested workspace is showing on another monitor, then the current
+workspace and requested workspace will swap positions with each other.
 
 
 # Requirements
 
 - [i3 window manager](https://i3wm.org/)
-- [i3-py](https://github.com/ziberna/i3-py)
+- [i3ipc](https://github.com/acrisci/i3ipc-python)
 
 
 # Install

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ workspace and requested workspace will swap positions with each other.
 # Requirements
 
 - [i3 window manager](https://i3wm.org/)
-- [i3ipc](https://github.com/acrisci/i3ipc-python)
+- [i3ipc Python module](https://github.com/acrisci/i3ipc-python)
 
 
 # Install
@@ -47,6 +47,12 @@ Download script
 ```
 cd ~/.i3
 git clone https://github.com/tmfink/i3-wk-switch.git
+```
+
+Install i3ipc
+
+```
+pip install i3ipc
 ```
 
 Add keybindings to `~/.i3/config`

--- a/i3-wk-switch.py
+++ b/i3-wk-switch.py
@@ -2,7 +2,7 @@
 
 """Emulates xmonad's workspace switching behavior in i3 and sway"""
 
-# pylint: disable=no-member,invalid-name
+# pylint: disable=no-member,invalid-name,too-many-function-args
 
 from __future__ import print_function
 

--- a/i3-wk-switch.py
+++ b/i3-wk-switch.py
@@ -73,9 +73,9 @@ def switch_workspace(num):
 def swap_visible_workspaces(wk_a, wk_b):
     """Swaps two workspaces that are visible"""
     switch_workspace(wk_a['num'])
-    i3.command('move workspace to output ' + wk_b['output'])
+    i3.command('move workspace to output %s' % wk_b['output'])
     switch_workspace(wk_b['num'])
-    i3.command('move workspace to output ' + wk_a['output'])
+    i3.command('move workspace to output %s' % wk_a['output'])
 
 
 def change_workspace(num):

--- a/i3-wk-switch.py
+++ b/i3-wk-switch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """Emulates xmonad's workspace switching behavior in i3"""
 

--- a/i3-wk-switch.py
+++ b/i3-wk-switch.py
@@ -10,8 +10,9 @@ import argparse
 import logging
 import sys
 from pprint import pformat
-import i3ipc
 import time
+
+import i3ipc
 
 i3 = i3ipc.Connection()
 

--- a/i3-wk-switch.py
+++ b/i3-wk-switch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Emulates xmonad's workspace switching behavior in i3"""
+"""Emulates xmonad's workspace switching behavior in i3 and sway"""
 
 # pylint: disable=no-member,invalid-name
 
@@ -10,10 +10,10 @@ import argparse
 import logging
 import sys
 from pprint import pformat
+import i3ipc
 import time
 
-import i3
-
+i3 = i3ipc.Connection()
 
 LOG = logging.getLogger('i3-wk-switch')
 
@@ -67,15 +67,15 @@ def get_workspace(num):
 
 def switch_workspace(num):
     """Switches to workspace number"""
-    i3.workspace('number %d' % num)
+    i3.command('workspace %d' % num)
 
 
 def swap_visible_workspaces(wk_a, wk_b):
     """Swaps two workspaces that are visible"""
     switch_workspace(wk_a['num'])
-    i3.command('move', 'workspace to output ' + wk_b['output'])
+    i3.command('move workspace to output ' + wk_b['output'])
     switch_workspace(wk_b['num'])
-    i3.command('move', 'workspace to output ' + wk_a['output'])
+    i3.command('move workspace to output ' + wk_a['output'])
 
 
 def change_workspace(num):


### PR DESCRIPTION
Switched to i3ipc instead of i3-py, the last update to i3-py was in 2012, i3ipc is actively developed. This also enables compatibility with Sway.