### PR TITLE
little bug + correct behaviour when hidden + focus now stays with wanted workspace

### DIFF
--- a/i3-wk-switch.py
+++ b/i3-wk-switch.py
@@ -137,7 +137,7 @@ def change_workspace(num):
         switch_workspace(num)
         move_workspace(original_output)
         return
-        
+
     LOG.debug('Wanted workspace is on other output')
 
     # Wanted workspace is visible, so swap workspaces

--- a/i3-wk-switch.py
+++ b/i3-wk-switch.py
@@ -70,6 +70,9 @@ def switch_workspace(num):
     """Switches to workspace number"""
     i3.command('workspace %d' % num)
 
+def move_workspace(s):
+    """Move current workspace to output"""
+    i3.command('move workspace to output %s' % s)
 
 def swap_visible_workspaces(wk_a, wk_b):
     """Swaps two workspaces that are visible"""
@@ -132,7 +135,9 @@ def change_workspace(num):
 
         # Switch to workspace on other output
         switch_workspace(num)
-
+        move_workspace(original_output)
+        return
+        
     LOG.debug('Wanted workspace is on other output')
 
     # Wanted workspace is visible, so swap workspaces
@@ -144,7 +149,7 @@ def change_workspace(num):
     # Focus on wanted workspace
     time.sleep(.15)
     LOG.debug('Setting focus to %s', original_output)
-    i3.command('focus', 'output', original_output)
+    i3.command('focus output %s' % original_output)
 
 
 def main():


### PR DESCRIPTION
1. Corrected a call to i3.command that didn't seem to work.

2. Corrected the behaviour in case want_workspace was hidden on another output. Don't really know what it was doing but it was clearly not as desired (by me, at least).

3. In case we have to swap workspaces, added that the focus should go to want_workspace.
