### PR TITLE
fix switch to hidden ws

### DIFF
--- a/i3-wk-switch.py
+++ b/i3-wk-switch.py
@@ -138,6 +138,9 @@ def change_workspace(num):
         # Switch to workspace on other output
         switch_workspace(num)
         move_workspace(original_output)
+        time.sleep(.15)
+        LOG.debug('Setting focus to %s', original_output)
+        i3.command('focus output %s' % original_output)
         return
 
     LOG.debug('Wanted workspace is on other output')


### PR DESCRIPTION
When switching to a hidden (not shown) ws on other output, focus ends on the wrong output.

I think this fixes that.

Sometimes visible empty workspaces cause bugs too, but I can't completely reproduce when it happens. I might try again later.

Thank you for this project, I needed this after changing from xmonad to i3, now I need to show all ws on the bar